### PR TITLE
Call WaitGetPoses() from CockpitLook for better latency

### DIFF
--- a/SteamVR.cpp
+++ b/SteamVR.cpp
@@ -154,7 +154,7 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, floa
 	if (g_pHMD->GetControllerState(unDevice, &state, sizeof(state)))
 	{
 		//vr::TrackedDevicePose_t trackedDevicePose;
-		//vr::TrackedDevicePose_t trackedDevicePoseArray[vr::k_unMaxTrackedDeviceCount];
+		vr::TrackedDevicePose_t trackedDevicePoseArray[vr::k_unMaxTrackedDeviceCount];
 		vr::HmdMatrix34_t poseMatrix;
 		vr::HmdQuaternionf_t q;
 		//vr::ETrackedDeviceClass trackedDeviceClass = vr::VRSystem()->GetTrackedDeviceClass(unDevice);
@@ -165,9 +165,9 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, floa
 		vr::VRCompositor()->GetFrameTiming(&frametiming);
 
 		//g_fPredictedSecondsToPhotons = GetFrameTimingRemaining + (m_nNumMisPresented / Prop_DisplayFrequency_Float) + Prop_SecondsFromVsyncToPhotons_Float;
-		g_fPredictedSecondsToPhotons = vr::VRCompositor()->GetFrameTimeRemaining() + frametiming.m_nNumVSyncsToFirstView / g_fHMDDisplayFreq + g_fVsyncToPhotons;
+		//g_fPredictedSecondsToPhotons = vr::VRCompositor()->GetFrameTimeRemaining() + frametiming.m_nNumVSyncsToFirstView / g_fHMDDisplayFreq + g_fVsyncToPhotons;
 		//log_debug("[DBG][CockpitLook] g_fPredictedSecondsToPhotons = %f",g_fPredictedSecondsToPhotons);
-		vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, g_fPredictedSecondsToPhotons, &g_hmdPose, 1);
+		//vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, g_fPredictedSecondsToPhotons, &g_hmdPose, 1);
 
 		/* Get the last pose predicted for the current frame during WaitGetPoses for the last frame.
 		   This should remove jitter although it may introduce some error due to the prediction when doing quick changes of velocity/direction.
@@ -175,11 +175,11 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, floa
 		*/
 		//vr::VRCompositor()->GetLastPoses(NULL, 0, trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount);
 		//vr::VRCompositor()->GetLastPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
-		//vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+		vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
 
-		//if (trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid) {
-		if (g_hmdPose.bPoseIsValid) {
-			//poseMatrix = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd].mDeviceToAbsoluteTracking; // This matrix contains all positional and rotational data.
+		if (trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid) {
+		//if (g_hmdPose.bPoseIsValid) {
+			g_hmdPose = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd]; // This matrix contains all positional and rotational data.
 			poseMatrix = g_hmdPose.mDeviceToAbsoluteTracking; // This matrix contains all positional and rotational data.
 			q = rotationToQuaternion(poseMatrix);
 			quatToEuler(q, yaw, pitch, &roll);


### PR DESCRIPTION
Necessary changes in CockpitLook for https://github.com/Prof-Butts/xwa_ddraw_d3d11/pull/41

It calls WaitGetPoses() from CockpitLook hook to do the frame sync and reduce the latency, as this is the first place in the frame where the pose is needed.

The drawback is that this placement is not optimal in terms of performance. It creates a big GPU bubble because xwingalliance.exe will not start sending draw calls until much later in the frame (when calling `ddraw.dll::Direct3DDevice::Execute()`)