### PR TITLE
Implement roll in CockpitLook

### DIFF
--- a/SteamVR.cpp
+++ b/SteamVR.cpp
@@ -133,7 +133,7 @@ void quatToEuler(vr::HmdQuaternionf_t q, float *yaw, float *roll, float *pitch) 
 	*roll = atan2(2.0f * q.x*q.w - 2.0f * q.y*q.z, 1.0f - 2.0f * sqx - 2.0f * sqz);
 }
 
-bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, float *z)
+bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, float *y, float *z)
 {
 	if (g_pHMD == NULL) {
 		log_debug("GetSteamVRPositional Data with g_pHMD = NULL");
@@ -148,7 +148,6 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, floa
 		log_debug("SteamVR initialized in the second attempt, continuing");
 	}
 
-	float roll;
 	vr::TrackedDeviceIndex_t unDevice = vr::k_unTrackedDeviceIndex_Hmd;
 	vr::Compositor_FrameTiming frametiming;
 	frametiming.m_nSize = sizeof(vr::Compositor_FrameTiming);
@@ -197,18 +196,10 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, floa
 			g_hmdPose = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd]; // This matrix contains all positional and rotational data.
 			poseMatrix = g_hmdPose.mDeviceToAbsoluteTracking; // This matrix contains all positional and rotational data.
 			q = rotationToQuaternion(poseMatrix);
-			quatToEuler(q, yaw, pitch, &roll);
-			//if (g_bCorrectedHeadTracking) {
-			if (false) {
-				// Disable positional tracking here if we are using the corrected tracking
-				// It will be applied later in ddraw
-				// This avoids using cockpit shake and reduces the jitter at the cost of some visible culling
-				*x = *y = *z = 0;
-			} else{
-				*x = poseMatrix.m[0][3];
-				*y = poseMatrix.m[1][3];
-				*z = poseMatrix.m[2][3];			
-			}
+			quatToEuler(q, yaw, pitch, roll);
+			*x = poseMatrix.m[0][3];
+			*y = poseMatrix.m[1][3];
+			*z = poseMatrix.m[2][3];
 			return true;
 		}
 		else

--- a/SteamVR.cpp
+++ b/SteamVR.cpp
@@ -58,6 +58,15 @@ void ShutdownSteamVR() {
 	log_debug("SteamVR shut down");
 }
 
+Matrix3 HmdMatrix34toMatrix3(const vr::HmdMatrix34_t& mat) {
+	Matrix3 matrixObj(
+		mat.m[0][0], mat.m[1][0], mat.m[2][0],
+		mat.m[0][1], mat.m[1][1], mat.m[2][1],
+		mat.m[0][2], mat.m[1][2], mat.m[2][2]
+	);
+	return matrixObj;
+}
+
 /*
  * Convert a rotation matrix to a normalized quaternion.
  * From: http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/
@@ -133,7 +142,145 @@ void quatToEuler(vr::HmdQuaternionf_t q, float *yaw, float *roll, float *pitch) 
 	*roll = atan2(2.0f * q.x*q.w - 2.0f * q.y*q.z, 1.0f - 2.0f * sqx - 2.0f * sqz);
 }
 
-bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, float *y, float *z)
+/* DEPRECATED, WE APPLY ROTATION MATRIX DIRECTLY INSTEAD
+Formulas from https://www.geometrictools.com/Documentation/EulerAngles.pdf
+
+The formulas are for Extrinsic convention, so we take the formulas for the rotation in inverse order
+(see https://en.wikipedia.org/wiki/Davenport_chained_rotations#Conversion_between_intrinsic_and_extrinsic_rotations)
+
+We should use ZYX to match the order of rotations in XWA (pitch->yaw->roll in ddraw). However, this convention has singularities
+in yaw = +-90, with an inversion of the axes that are not acceptable.
+
+An alternative YZX is used to move the singularity to roll=+-90 which is a much less pose, and behavior is similar to the original
+matrix->quaternion->Euler functions.
+
+*/
+void rotMatrixToEuler(vr::HmdMatrix34_t pose, float* yaw, float* pitch, float* roll)
+{
+	float thetaX, thetaY, thetaZ;
+
+/* Extrinsic ZYX */
+	//if(pose.m[2][0] < 0.999f)
+	//{
+	//	if(pose.m[2][0] > -0.999f)
+	//	{
+	//		thetaY = asin(-pose.m[2][0]);
+	//		thetaZ = atan2(pose.m[1][0], pose.m[0][0]);
+	//		thetaX = atan2(pose.m[2][1], pose.m[2][2]);
+	//	}
+	//	else // r20 = -1
+	//	{
+	//		thetaY = PI / 2;
+	//		thetaZ = -(atan2(-pose.m[1][2], pose.m[1][1]));
+	//		thetaX = 0;
+	//	}
+	//}
+	//else // r20 = +1
+	//{
+	//	thetaY = -PI / 2;
+	//	thetaZ = atan2(-pose.m[1][2], pose.m[1][1]);
+	//	thetaX = 0;
+	//}
+
+/* Extrinsic ZXY */
+	//if(pose.m[2][1] < 0.999f)
+	//{
+	//	if(pose.m[2][1] > -0.999f)
+	//	{
+	//		thetaX = asin(pose.m[2][1]);
+	//		thetaZ = atan2(-pose.m[0][1], pose.m[1][1]);
+	//		thetaY = atan2(-pose.m[2][0], pose.m[2][2]);
+	//	}
+	//	else // r21 = -1
+	//	{
+	//		thetaX = -PI / 2;
+	//		thetaZ = -(atan2(pose.m[0][2], pose.m[0][0]));
+	//		thetaY = 0;
+	//	}
+	//}
+	//else // r21 = +1
+	//{
+	//	thetaX = PI / 2;
+	//	thetaZ = atan2(pose.m[0][2], pose.m[0][0]);
+	//	thetaY = 0;
+	//}
+
+/* Extrinsic XYZ */
+	//if (pose.m[0][2] < 0.999f)
+	//{
+	//	if (pose.m[0][2] > -0.999f)
+	//	{
+	//		thetaY = asin(pose.m[0][2]);
+	//		thetaX = atan2(-pose.m[1][2], pose.m[2][2]);
+	//		thetaZ = atan2(-pose.m[0][1], pose.m[0][0]);
+	//	}
+	//	else // r21 = -1
+	//	{
+	//		thetaY = -PI / 2;
+	//		thetaX = -(atan2(pose.m[1][0], pose.m[1][1]));
+	//		thetaZ = 0;
+	//	}
+	//}
+	//else // r21 = +1
+	//{
+	//	thetaY = PI / 2;
+	//	thetaX = atan2(pose.m[1][0], pose.m[1][1]);
+	//	thetaZ = 0;
+	//}
+
+/* Extrinsic XZY*/
+	//if (pose.m[0][1] < 0.999f)
+	//{
+	//	if (pose.m[0][1] > -0.999f)
+	//	{
+	//		thetaZ = asin(-pose.m[0][1]);
+	//		thetaX = atan2(pose.m[2][1], pose.m[1][1]);
+	//		thetaY = atan2(pose.m[0][2], pose.m[0][0]);
+	//	}
+	//	else // r01 = -1
+	//	{
+	//		thetaZ = PI / 2;
+	//		thetaX = -(atan2(-pose.m[2][0], pose.m[2][2]));
+	//		thetaY = 0;
+	//	}
+	//}
+	//else // r01 = +1
+	//{
+	//	thetaZ = -PI / 2;
+	//	thetaX = atan2(-pose.m[2][0], pose.m[2][2]);
+	//	thetaY = 0;
+	//}
+
+/* Extrinsic YZX */
+	if (pose.m[1][0] < 0.999f)
+	{
+		if (pose.m[1][0] > -0.999f)
+		{
+			thetaZ = asin(pose.m[1][0]);
+			thetaY = atan2(-pose.m[2][0], pose.m[0][0]);
+			thetaX = atan2(-pose.m[1][2], pose.m[1][1]);
+		}
+		else // r10 = -1
+		{
+			thetaZ = -PI / 2;
+			thetaY = -(atan2(pose.m[2][1], pose.m[2][2]));
+			thetaX = 0;
+		}
+	}
+	else // r10 = +1
+	{
+		thetaZ = PI / 2;
+		thetaY = atan2(pose.m[2][1], pose.m[2][2]);
+		thetaX = 0;
+	}
+
+
+	*pitch = thetaX;
+	*yaw = -thetaY;
+	*roll = -thetaZ;
+}
+
+bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, float *y, float *z, Matrix3* rotMatrix)
 {
 	if (g_pHMD == NULL) {
 		log_debug("GetSteamVRPositional Data with g_pHMD = NULL");
@@ -195,6 +342,9 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, f
 		//if (g_hmdPose.bPoseIsValid) {
 			g_hmdPose = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd]; // This matrix contains all positional and rotational data.
 			poseMatrix = g_hmdPose.mDeviceToAbsoluteTracking; // This matrix contains all positional and rotational data.
+			//rotMatrixToEuler(poseMatrix, yaw, pitch, roll);
+			*rotMatrix = HmdMatrix34toMatrix3(poseMatrix);
+
 			q = rotationToQuaternion(poseMatrix);
 			quatToEuler(q, yaw, pitch, roll);
 			*x = poseMatrix.m[0][3];

--- a/SteamVR.h
+++ b/SteamVR.h
@@ -1,10 +1,12 @@
 #pragma once
 #include <headers/openvr.h>
 #include "cockpitlook.h"
+#include "Matrices.h"
 
 extern float g_fPredictedSecondsToPhotons;
 extern bool g_bCorrectedHeadTracking;
 
 bool InitSteamVR();
 void ShutdownSteamVR();
-bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, float *y, float *z);
+Matrix3 HmdMatrix34toMatrix3(const vr::HmdMatrix34_t& mat);
+bool GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix3* poseMatrix);

--- a/SteamVR.h
+++ b/SteamVR.h
@@ -7,4 +7,4 @@ extern bool g_bCorrectedHeadTracking;
 
 bool InitSteamVR();
 void ShutdownSteamVR();
-bool GetSteamVRPositionalData(float *yaw, float *pitch, float *x, float *y, float *z);
+bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, float *y, float *z);

--- a/XWAFramework.h
+++ b/XWAFramework.h
@@ -50,7 +50,7 @@ const auto DisplayMessage = (int(*)(int messageIndex, int playerIndex))0x497D40;
 const auto GetKeyboardDeviceState = (int(*)())0x42B900;
 const auto DirectInputKeyboardReaquire = (char(*)())0x42B920;
 const auto Vector3Transform = (void* (*)(Vector3_float* vec, XwaMatrix3x3* mat)) 0x439B30;
-
+const auto DoRotation = (void (*)(int, int, int, __int16)) 0x440E40;
 
 
 // Globals from XWA

--- a/XWAFramework.h
+++ b/XWAFramework.h
@@ -161,3 +161,13 @@ const auto g_localPlayerObjectIndex = (int *)0x0634370;
 const auto g_localPlayerObjectIndex2 = (int *)0x0631B70;
 
 const auto *g_playerInHangar = (unsigned int *)0x09C6E40;
+
+const auto g_objectTransformRear_X = (int *)0x910934;
+const auto g_objectTransformRear_Y = (int *)0x910938;
+const auto g_objectTransformRear_Z = (int *)0x910944;
+const auto g_objectTransformRight_X = (int*)0x8D93D8;
+const auto g_objectTransformRight_Y = (int*)0x8D93C8;
+const auto g_objectTransformRight_Z = (int*)0x8D93D0;
+const auto g_objectTransformUp_X = (int*)0x8D9400;
+const auto g_objectTransformUp_Y = (int*)0x8D93E8;
+const auto g_objectTransformUp_Z = (int*)0x8D93F4;

--- a/cockpitlook.cpp
+++ b/cockpitlook.cpp
@@ -1875,17 +1875,18 @@ int UpdateCameraTransformHook(int* params) {
 	// - the targeting reticle is not anymore where it should be.
 
 	void (*DoRotation)(int, int, int, __int16) = (void (*)(int, int, int, __int16)) 0x440E40;
-
-	// Obtain the current rear-looking vector that we need to rotate around for applying roll
-	int* g_objectTransformRear_X = (int*)0x910934;
-	int* g_objectTransformRear_Y = (int*)0x910938;
-	int* g_objectTransformRear_Z = (int*)0x910944;
-
 	// Apply the expected Pitch rotation
 	DoRotation(params[0], params[1], params[2], params[3]);
 
-	DoRotation(*g_objectTransformRear_X, *g_objectTransformRear_Y, *g_objectTransformRear_Z, (short) -g_fRoll);
-		
+
+	if (g_bCorrectedHeadTracking) {
+		// Only apply roll for the new corrected tracking, for now.
+		// Obtain the current rear-looking vector that we need to rotate around for applying roll
+		int* g_objectTransformRear_X = (int*)0x910934;
+		int* g_objectTransformRear_Y = (int*)0x910938;
+		int* g_objectTransformRear_Z = (int*)0x910944;
+		DoRotation(*g_objectTransformRear_X, *g_objectTransformRear_Y, *g_objectTransformRear_Z, (short)-g_fRoll);
+	}		
 	return 0;
 }
 

--- a/cockpitlook.cpp
+++ b/cockpitlook.cpp
@@ -1844,6 +1844,12 @@ void InitSharedMem() {
 	pSharedData->bDataReady = true;
 }
 
+/*
+ NOT CURRENTLY USED
+ This function runs when UpdateCameraTransform is called from PlayerCameraUpdate() for the normal in-flight camera (not map, not external)
+
+ It does NOT currently modify the XWA engine behavior, just calls the original function.
+*/
 int UpdateCameraTransformHook(int* params)
 {
 	//log_debug("Running hooked UpdateCameraTransform()");
@@ -1860,13 +1866,16 @@ int UpdateCameraTransformHook(int* params)
 		int object,
 		int playerIndex)) 0x43F8E0;
 
-	// Apply rotations coming from XWA engine
-	/*g_headPitch += params[4];
-	g_headYaw += params[5];*/
-	g_headPitch = params[4];
-	g_headYaw = params[5];
-
+	// Apply headtracking to rotations coming from XWA engine
+	/*
+	g_headPitch += params[4];
+	g_headYaw += params[5];
 	return UpdateCameraTransform(params[0], params[1], params[2], params[3], g_headPitch, g_headYaw, params[6], params[7]);
+	*/
+
+	// Since the headtracking is either applied in CockpitLookHook through MousePosition_X,Y, or through the matrix in DoRotate()
+	// We don't need to apply it here.
+	return UpdateCameraTransform(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);
 }
 
 int CockpitPositionTransformHook(int* params)
@@ -1903,8 +1912,10 @@ int DoRotationPitchHook(int* params)
 			(float)*g_objectTransformRear_X, (float)*g_objectTransformRear_Y, (float)*g_objectTransformRear_Z
 		);
 
-		// Apply the headtracking from
+		// Apply the rotation matrix from headtracking
 		xwaCameraTransform *= g_headRotation;
+
+		// Rewrite the composed rotation matrix (original+headtracking) into XWA globals
 		*g_objectTransformRight_X = -(int)xwaCameraTransform[0];
 		*g_objectTransformRight_Y = -(int)xwaCameraTransform[1];
 		*g_objectTransformRight_Z = -(int)xwaCameraTransform[2];

--- a/cockpitlook.h
+++ b/cockpitlook.h
@@ -5,6 +5,6 @@ const float PI = 3.141592f;
 const float RAD_TO_DEG = 180.0f / PI;
 
 int CockpitLookHook(int* params);
-//int PlayerCameraUpdateHook(int* params);
-int CockpitPositionTransformHook(int* params);
 int UpdateCameraTransformHook(int* params);
+int CockpitPositionTransformHook(int* params);
+int DoRotationHook(int* params);

--- a/cockpitlook.h
+++ b/cockpitlook.h
@@ -7,4 +7,5 @@ const float RAD_TO_DEG = 180.0f / PI;
 int CockpitLookHook(int* params);
 int UpdateCameraTransformHook(int* params);
 int CockpitPositionTransformHook(int* params);
-int DoRotationHook(int* params);
+int DoRotationPitchHook(int* params);
+int DoRotationYawHook(int* params);

--- a/cockpitlook.h
+++ b/cockpitlook.h
@@ -5,5 +5,6 @@ const float PI = 3.141592f;
 const float RAD_TO_DEG = 180.0f / PI;
 
 int CockpitLookHook(int* params);
-int PlayerCameraUpdateHook(int* params);
+//int PlayerCameraUpdateHook(int* params);
 int CockpitPositionTransformHook(int* params);
+int UpdateCameraTransformHook(int* params);

--- a/hooks.h
+++ b/hooks.h
@@ -8,6 +8,8 @@ static const HookFunction g_hookFunctions[] =
 	{ 0x4F9A66, CockpitLookHook },
 	//{ 0x4F219B, PlayerCameraUpdateHook }, // Fix according to RandomStarfighter's instructions
 	{ 0x497ABB, CockpitPositionTransformHook },
+	{ 0x43FB57, UpdateCameraTransformHook }, //DoRotation(Pitch)
+	//{ 0x43FB67, UpdateCameraTransformHook }, //DoRotation(Yaw)
 };
 
 static const HookPatchItem g_patch[] =
@@ -17,11 +19,17 @@ static const HookPatchItem g_patch[] =
 	// Entry
 	// First hook in PlayerInflightSystemInput to overwrite the mouselook values for pitch,yaw.
 	{ 0xF8E61, "66399369A08B00", "E8BAF00A009090" },
-	// Second hook in PlayerCameraUpdate to add positional tracking (credit: RandomStarfighter)
-	//{ 0x4F2196 - 0x400C00, "E885C6FFFF", "E885690B00"},
-	// Hook last call to Vector3Transform() inside UpdatePlayerMovement() that provides the values for CockpitPositionTransformed()
+
+	// Hook last call to Vector3Transform() inside UpdatePlayerMovement() that provides the values for CockpitPositionTransformed.
+	// To add positional tracking. This only works in cockpit view mode!
 	{ 0x497AB6 - 0x400C00, "E87520FAFF", "E865101100"},
 
+	// Hook call to DoRotation(Pitch) inside UpdateCameraTransform (0x43FB52)
+	// jmp ((0x5A8B20 - 0x43FB57) = 0x168FC9
+	{ 0x43FB52 - 0x400C00, "E8E9120000", "E8C98F1600"},
+
+	// Hook call to DoRotation(Yaw) inside UpdateCameraTransform (0x43FB52)
+	//{ 0x43FB62 - 0x400C00, "E8D9120000", "E8B98F1600"},
 };
 
 static const HookPatch g_patches[] =

--- a/hooks.h
+++ b/hooks.h
@@ -6,7 +6,7 @@
 static const HookFunction g_hookFunctions[] =
 {
 	{ 0x4F9A66, CockpitLookHook },
-	{ 0x4EE9DA, UpdateCameraTransformHook },
+	//{ 0x4EE9DA, UpdateCameraTransformHook },
 	{ 0x497ABB, CockpitPositionTransformHook },
 	{ 0x43FB57, DoRotationPitchHook}, //DoRotation(Pitch)
 	{ 0x43FB67, DoRotationYawHook }, //DoRotation(Yaw)
@@ -22,7 +22,7 @@ static const HookPatchItem g_patch[] =
 
 	// Hook call to UpdateCameraTransform for in-cockpit flight inside PlayerCameraUpdate()
 	// call (0x5A8B20 - 0x4EE9DA) = 0xBA146
-	{ 0x4EE9D5 - 0x400C00, "E8060FF5FF", "E846A10B00"},
+	//{ 0x4EE9D5 - 0x400C00, "E8060FF5FF", "E846A10B00"},
 
 	// Hook last call to Vector3Transform() inside UpdatePlayerMovement() that provides the values for CockpitPositionTransformed.
 	// To add positional tracking. This only works in cockpit view mode!

--- a/hooks.h
+++ b/hooks.h
@@ -8,8 +8,8 @@ static const HookFunction g_hookFunctions[] =
 	{ 0x4F9A66, CockpitLookHook },
 	{ 0x4EE9DA, UpdateCameraTransformHook },
 	{ 0x497ABB, CockpitPositionTransformHook },
-	{ 0x43FB57, DoRotationHook}, //DoRotation(Pitch)
-	//{ 0x43FB67, DoRotationHook }, //DoRotation(Yaw)
+	{ 0x43FB57, DoRotationPitchHook}, //DoRotation(Pitch)
+	{ 0x43FB67, DoRotationYawHook }, //DoRotation(Yaw)
 };
 
 static const HookPatchItem g_patch[] =
@@ -33,7 +33,7 @@ static const HookPatchItem g_patch[] =
 	{ 0x43FB52 - 0x400C00, "E8E9120000", "E8C98F1600"},
 
 	// Hook call to DoRotation(Yaw) inside UpdateCameraTransform (0x43FB52)
-	//{ 0x43FB62 - 0x400C00, "E8D9120000", "E8B98F1600"},
+	{ 0x43FB62 - 0x400C00, "E8D9120000", "E8B98F1600"},
 };
 
 static const HookPatch g_patches[] =

--- a/hooks.h
+++ b/hooks.h
@@ -6,10 +6,10 @@
 static const HookFunction g_hookFunctions[] =
 {
 	{ 0x4F9A66, CockpitLookHook },
-	//{ 0x4F219B, PlayerCameraUpdateHook }, // Fix according to RandomStarfighter's instructions
+	{ 0x4EE9DA, UpdateCameraTransformHook },
 	{ 0x497ABB, CockpitPositionTransformHook },
-	{ 0x43FB57, UpdateCameraTransformHook }, //DoRotation(Pitch)
-	//{ 0x43FB67, UpdateCameraTransformHook }, //DoRotation(Yaw)
+	{ 0x43FB57, DoRotationHook}, //DoRotation(Pitch)
+	//{ 0x43FB67, DoRotationHook }, //DoRotation(Yaw)
 };
 
 static const HookPatchItem g_patch[] =
@@ -20,12 +20,16 @@ static const HookPatchItem g_patch[] =
 	// First hook in PlayerInflightSystemInput to overwrite the mouselook values for pitch,yaw.
 	{ 0xF8E61, "66399369A08B00", "E8BAF00A009090" },
 
+	// Hook call to UpdateCameraTransform for in-cockpit flight inside PlayerCameraUpdate()
+	// call (0x5A8B20 - 0x4EE9DA) = 0xBA146
+	{ 0x4EE9D5 - 0x400C00, "E8060FF5FF", "E846A10B00"},
+
 	// Hook last call to Vector3Transform() inside UpdatePlayerMovement() that provides the values for CockpitPositionTransformed.
 	// To add positional tracking. This only works in cockpit view mode!
 	{ 0x497AB6 - 0x400C00, "E87520FAFF", "E865101100"},
 
 	// Hook call to DoRotation(Pitch) inside UpdateCameraTransform (0x43FB52)
-	// jmp ((0x5A8B20 - 0x43FB57) = 0x168FC9
+	// call ((0x5A8B20 - 0x43FB57) = 0x168FC9
 	{ 0x43FB52 - 0x400C00, "E8E9120000", "E8C98F1600"},
 
 	// Hook call to DoRotation(Yaw) inside UpdateCameraTransform (0x43FB52)


### PR DESCRIPTION
New hooks implemented in call to DoRotation() inside UpdateCameraMatrix(), to ~~inject an additional rotation for the roll~~ apply the full rotation matrix from headtracking with matrix multiplication. This gets rid of gimbal lock issues and distortions linked to decomposition in Euler angles.

This breaks some things that need to be fixed.
 - ~~Regular headtracking (non-pose-corrected). I need to check for the parameter before injecting the roll in cockpitlook or it is applied twice (cockpitlook and ddraw).~~ FIXED
 - ~~the sound (it enters some kind of loop). Maybe the DirectSound3D is impacted by the modified state of the transformation matrix.~~ SteamVR issue, fixed with a restart.
 - the targeting reticle is not anymore where it should be. The code that calculates its position is not prepared for camera roll.
