### PR TITLE
Fixed reticle pips wrong position due to headtracking

### DIFF
--- a/XWAFramework.h
+++ b/XWAFramework.h
@@ -51,6 +51,7 @@ const auto GetKeyboardDeviceState = (int(*)())0x42B900;
 const auto DirectInputKeyboardReaquire = (char(*)())0x42B920;
 const auto Vector3Transform = (void* (*)(Vector3_float* vec, XwaMatrix3x3* mat)) 0x439B30;
 const auto DoRotation = (void (*)(int, int, int, __int16)) 0x440E40;
+const auto TransformVector = (int (*)(ObjectEntry*, int, int, int)) 0x4A2FB0;
 
 
 // Globals from XWA

--- a/cockpitlook.h
+++ b/cockpitlook.h
@@ -11,3 +11,4 @@ int MapCameraUpdateHook(int* params);
 int CockpitPositionTransformHook(int* params);
 int DoRotationPitchHook(int* params);
 int DoRotationYawHook(int* params);
+int SetupReticleHook(int* params);

--- a/hooks.h
+++ b/hooks.h
@@ -14,6 +14,7 @@ static const HookFunction g_hookFunctions[] =
 	{ 0x497ABB, CockpitPositionTransformHook },
 	{ 0x43FB57, DoRotationPitchHook}, //DoRotation(Pitch)
 	{ 0x43FB67, DoRotationYawHook }, //DoRotation(Yaw)
+	{ 0x4654A6, SetupReticleHook }, //TransformVector() inside SetupReticle()
 };
 
 static const HookPatchItem g_patch[] =
@@ -49,7 +50,12 @@ static const HookPatchItem g_patch[] =
 	{ 0x43FB52 - 0x400C00, "E8E9120000", "E8C98F1600"},
 
 	// Hook call to DoRotation(Yaw) inside UpdateCameraTransform (0x43FB52)
+	// call((0x5A8B20 - 0x43FB67) = 0x168FB9
 	{ 0x43FB62 - 0x400C00, "E8D9120000", "E8B98F1600"},
+
+	// Hook call to TransformVector() inside SetupReticle () (0x4652F0)
+	// call((0x5A8B20 - 0x4654A6) = 0x168FC9
+	{ 0x4654A1 - 0x400C00, "E80ADB0300", "E87A361400"},
 };
 
 static const HookPatch g_patches[] =


### PR DESCRIPTION
Prevent headtracking to be injected until the reticle has been properly set up.