### PR TITLE
New (hopefully) complete fix for reticle pips misalignment and remove pose corrected tracking.

### DIFF
--- a/SharedMem.h
+++ b/SharedMem.h
@@ -17,8 +17,11 @@ struct SharedData {
 	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
 	// These values are normalized in the range -1..1
 	float JoystickYaw, JoystickPitch;
-	// Present() counter, written by ddraw
-	int PresentCounter;
+	// Flag to indicate that the reticle needs setup, to inhibit tracking and avoid roll messing with
+	// the pips positions.
+	// Set to 0 by ddraw when the game starts a mission (in OnSizeChanged())
+	// Set to 1 by a hook in the SetupReticle() XWA function.
+	int bIsReticleSetup;
 
 	SharedData() {
 		this->POVOffsetX = 0.0f;
@@ -33,7 +36,7 @@ struct SharedData {
 		this->Z = 0.0f;
 		this->JoystickYaw = 0.0f;
 		this->JoystickPitch = 0.0f;
-		this->PresentCounter = 0;
+		this->bIsReticleSetup = 0;
 	}
 };
 

--- a/SteamVR.cpp
+++ b/SteamVR.cpp
@@ -8,7 +8,6 @@
 constexpr float DEFAULT_PREDICTED_SECONDS_TO_PHOTONS = 0.0f;
 float g_fPredictedSecondsToPhotons = DEFAULT_PREDICTED_SECONDS_TO_PHOTONS;
 float g_fVsyncToPhotons, g_fHMDDisplayFreq = 0;
-bool g_bCorrectedHeadTracking = true;
 
 void log_debug(const char *format, ...);
 bool g_bSteamVRInitialized = false;
@@ -313,39 +312,11 @@ bool GetSteamVRPositionalData(float *yaw, float *pitch, float *roll, float *x, f
 	vr::VRControllerState_t state;
 	if (g_pHMD->GetControllerState(unDevice, &state, sizeof(state)))
 	{
-		//vr::TrackedDevicePose_t trackedDevicePose;
 		vr::TrackedDevicePose_t trackedDevicePoseArray[vr::k_unMaxTrackedDeviceCount];
 		vr::HmdMatrix34_t poseMatrix;
 		vr::HmdQuaternionf_t q;
-		//vr::ETrackedDeviceClass trackedDeviceClass = vr::VRSystem()->GetTrackedDeviceClass(unDevice);
 
-		//vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0.029, &trackedDevicePose, 1);
-		//vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0.042f, &g_hmdPose, 1);
-		//vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0.011f, &g_hmdPose, 1);
-		//vr::VRCompositor()->GetFrameTiming(&frametiming);
-
-		//g_fPredictedSecondsToPhotons = GetFrameTimingRemaining + (m_nNumMisPresented / Prop_DisplayFrequency_Float) + Prop_SecondsFromVsyncToPhotons_Float;
-		//g_fPredictedSecondsToPhotons = vr::VRCompositor()->GetFrameTimeRemaining() + frametiming.m_nNumVSyncsToFirstView / g_fHMDDisplayFreq + g_fVsyncToPhotons;
-		//log_debug("[DBG][CockpitLook] g_fPredictedSecondsToPhotons = %f",g_fPredictedSecondsToPhotons);
-		//vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, g_fPredictedSecondsToPhotons, &g_hmdPose, 1);
-
-		if (g_bCorrectedHeadTracking) {
-			// Get the last pose predicted for the current frame during WaitGetPoses() of the previous frame (pGamePoseArray parameter).
-			vr::VRCompositor()->GetLastPoses(NULL, 0, trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount);
-			// This allows to call WaitGetPoses() in ddraw.dll::Direct3DDevice::Execute(), just before the Direct3D rendering starts.
-			// This way the CPU can continue working while the GPU is drawing the previous frame, which improves performance.
-			// It also delegates the prediction time calculations to WaitGetPoses as part of running start algorithm.
-			// To avoid jitter, ddraw will need to compensate the difference between the predicted HMD pose used here
-			// and the actual one at the time of starting the GPU rendering.
-		}
-		else {
-			// Legacy head tracking, with sub-optimal performance and bigger latency, but no jitter from pose prediction errors.
-			// CockpitLookHook will block the CPU work until the vsync, waiting for the previous frame to finish rendering in GPU.
-			// ddraw.dll will use the same pose obtained here by calling GetLastPoses(), but by that time it will be "old"
-			// especially for low FPS situations.
-			vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
-		}
-
+		vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
 
 		if (trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid) {
 		//if (g_hmdPose.bPoseIsValid) {

--- a/cockpitlook.cpp
+++ b/cockpitlook.cpp
@@ -33,7 +33,6 @@ HWND g_hWnd = NULL;
 extern bool g_bSteamVRInitialized;
 bool g_bForceSteamVRShutdown = false;
 bool g_bHeadtrackingApplied = false;
-bool g_bIsReticleSetup = false;
 
 // The hooks are loaded before ddraw, so we can create the shared memory handle here
 SharedMem g_SharedMem(true);


### PR DESCRIPTION
Use a new flag in shared memory (bIsReticleSetup) that is reset at the start of a mission by ddraw, and set to 1 by a hook in XWA SetupReticle()

I have also removed the option of pose_corrected_headtracking. Now WaitGetPoses() will always be called by CockpitLook.