### PR TITLE
Use class template and semaphore for shared memory

### DIFF
--- a/Hook_XWACockpitLook.vcxproj
+++ b/Hook_XWACockpitLook.vcxproj
@@ -22,33 +22,31 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{B7D1532C-312D-4A20-97D7-E87D1A129FC4}</ProjectGuid>
     <RootNamespace>HookXWASample</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>Hook_CockpitLook</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -157,6 +155,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="cockpitlook.h" />
     <ClInclude Include="SharedMem.h" />
+    <ClInclude Include="SharedMemTemplate.h" />
     <ClInclude Include="SteamVR.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Telemetry.h" />

--- a/Hook_XWACockpitLook.vcxproj.filters
+++ b/Hook_XWACockpitLook.vcxproj.filters
@@ -98,6 +98,9 @@
     <ClInclude Include="SharedMem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="SharedMemTemplate.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Hook_XWACockpitLook.rc">

--- a/SharedMem.h
+++ b/SharedMem.h
@@ -1,73 +1,39 @@
 #pragma once
 
 #include <windows.h>
+#include "SharedMemTemplate.h"
 
-// This is the actual data that will be shared across DLLs. It contains
-// a mixture of custom fields and a generic pointer to share whatever else
-// we need later.
-struct SharedData {
+struct SharedMemDataCockpitLook {
 	// Offset added to the current POV when VR is active. This is controlled by ddraw
 	float POVOffsetX, POVOffsetY, POVOffsetZ;
-	void *pDataPtr;
 	// Euler angles, in degrees, for the current camera matrix coming from SteamVR. This is
 	// written by CockpitLookHook:
 	float Yaw, Pitch, Roll;
 	// Positional tracking data. Written by CockpitLookHook:
 	float X, Y, Z;
-	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
-	// These values are normalized in the range -1..1
-	float JoystickYaw, JoystickPitch;
 	// Flag to indicate that the reticle needs setup, to inhibit tracking and avoid roll messing with
 	// the pips positions.
 	// Set to 0 by ddraw when the game starts a mission (in OnSizeChanged())
 	// Set to 1 by a hook in the SetupReticle() XWA function.
 	int bIsReticleSetup;
 
-	SharedData() {
+	SharedMemDataCockpitLook() {
 		this->POVOffsetX = 0.0f;
 		this->POVOffsetY = 0.0f;
 		this->POVOffsetZ = 0.0f;
-		this->pDataPtr = NULL;
 		this->Yaw = 0.0f;
 		this->Pitch = 0.0f;
 		this->Roll = 0.0f;
 		this->X = 0.0f;
 		this->Y = 0.0f;
 		this->Z = 0.0f;
-		this->JoystickYaw = 0.0f;
-		this->JoystickPitch = 0.0f;
 		this->bIsReticleSetup = 0;
 	}
 };
 
-// This hook loads before ddraw, so it contains the singleton that will be shared.
-extern SharedData g_SharedData;
+void InitSharedMem();
 
-// This is the data that will be shared between different DLLs
-// The bDataReady is set to true once the writer has initialized
-// the structure.
-// pDataPtr points to the actual data to be shared in the regular
-// heap space
-struct SharedDataProxy {
-	bool bDataReady;
-	SharedData *pSharedData;
-};
+constexpr auto SHARED_MEM_NAME_COCKPITLOOK = L"Local\\CockpitLookHook";
 
-constexpr auto SHARED_MEM_NAME = "Local\\CockpitLookHook";
-constexpr auto SHARED_MEM_SIZE = sizeof(SharedDataProxy);
-
-// This is the shared memory handler. Call GetMemoryPtr to get a pointer
-// to a SharedData structure
-class SharedMem {
-private:
-	HANDLE hMapFile;
-	void *pSharedMemPtr;
-	bool InitMemory(bool OpenCreate);
-
-public:
-	// Specify true in OpenCreate to create the shared memory handle. Set it to false to
-	// open an existing shared memory handle.
-	SharedMem(bool OpenCreate);
-	~SharedMem();
-	void *GetMemoryPtr();
-};
+extern SharedMem<SharedMemDataCockpitLook> g_SharedMem;
+extern SharedMemDataCockpitLook* g_SharedData;

--- a/SharedMemTemplate.h
+++ b/SharedMemTemplate.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <string>
+
+template<class T>
+class SharedMem
+{
+public:
+	SharedMem(LPCWSTR name, bool createIfNotExists, bool availableOnCreate);
+	~SharedMem();
+
+	T* GetMemoryPointer();
+	bool IsDataReady();
+	void SetDataReady();
+
+private:
+	HANDLE hMapFile;
+	HANDLE hSemaphore;
+	T* pSharedData;
+};
+
+template<class T>
+SharedMem<T>::SharedMem(LPCWSTR name, bool createIfNotExists, bool availableOnCreate)
+{
+	pSharedData = nullptr;
+	hSemaphore = NULL;
+
+	if (createIfNotExists)
+	{
+		hMapFile = CreateFileMappingW(
+			INVALID_HANDLE_VALUE,    // use paging file
+			NULL,                    // default security
+			PAGE_READWRITE,          // read/write access
+			0,                       // maximum object size (high-order DWORD)
+			sizeof(T),         // maximum object size (low-order DWORD)
+			name);        // name of mapping object
+	}
+	else
+	{
+		hMapFile = OpenFileMappingW(
+			FILE_MAP_ALL_ACCESS,   // read/write access
+			FALSE,                 // do not inherit the name
+			name);      // name of mapping object
+	}
+
+	if (!hMapFile)
+	{
+		return;
+	}
+
+	pSharedData = (T*)MapViewOfFile(
+		hMapFile,   // handle to map object
+		FILE_MAP_ALL_ACCESS, // read/write permission
+		0,
+		0,
+		sizeof(T));
+
+	LONG initialCount = availableOnCreate ? 1 : 0;
+	initialCount = 1;
+	std::wstring semaphoreName = name;
+	semaphoreName.append(L"Semaphore");
+	hSemaphore = CreateSemaphoreW(
+		NULL,					// default security attributes
+		initialCount,			// initial count
+		1,						// maximum count
+		semaphoreName.c_str()	// semaphore name);
+	);
+}
+
+template<class T>
+SharedMem<T>::~SharedMem()
+{
+	UnmapViewOfFile(pSharedData);
+	CloseHandle(hMapFile);
+	CloseHandle(hSemaphore);
+}
+
+template<class T>
+T* SharedMem<T>::GetMemoryPointer()
+{
+	return pSharedData;
+}
+
+template<class T>
+bool SharedMem<T>::IsDataReady()
+{
+	if (hSemaphore == NULL) return false;
+	DWORD dwWaitResult;
+	dwWaitResult = WaitForSingleObject(hSemaphore, 0);
+	switch (dwWaitResult) {
+		// The semaphore was signaled, the data is ready
+	case WAIT_OBJECT_0:
+		// We release it again immediately since we don't need exclusive or atomic access
+		// (there are no concurrent threads)
+		ReleaseSemaphore(hSemaphore, 1, NULL);
+		return true;
+		break;
+
+		// The semaphore was nonsignaled, so a time-out occurred.
+		// This should only happen when the data is not ready to be accessed
+		// (missing/disabled hook, not initialized or not generating data.
+	case WAIT_TIMEOUT:
+		return false;
+		break;
+	}
+	return false;
+}
+
+template<class T>
+void SharedMem<T>::SetDataReady()
+{
+	ReleaseSemaphore(hSemaphore, 1, NULL);
+}

--- a/SteamVR.cpp
+++ b/SteamVR.cpp
@@ -13,7 +13,6 @@ void log_debug(const char *format, ...);
 bool g_bSteamVRInitialized = false;
 vr::IVRSystem *g_pHMD = NULL;
 vr::IVRChaperone* g_pChaperone = NULL;
-extern SharedMem g_SharedMem;
 extern vr::TrackedDevicePose_t g_hmdPose;
 
 bool InitSteamVR()
@@ -37,18 +36,6 @@ bool InitSteamVR()
 	g_fHMDDisplayFreq = g_pHMD->GetFloatTrackedDeviceProperty(unDevice, vr::ETrackedDeviceProperty::Prop_DisplayFrequency_Float);
 	g_pChaperone = vr::VRChaperone();
 
-	/*
-	// If we ever share any SteamVR data between this hook and ddraw, we should put that here.
-
-	// Put the address of g_hmdPose in shared memory. We only need to do this once.
-	// Setting bDataReady to true means that pDataPtr has been initialized to a valid
-	// address.
-	SharedDataProxy* pSharedData = (SharedDataProxy *)g_SharedMem.GetMemoryPtr();
-	if (pSharedData != nullptr) {
-		pSharedData->pSharedData = &(g_hmdPose);
-		pSharedData->bDataReady = true;
-	}
-	*/
 	return true;
 }
 


### PR DESCRIPTION
Use a class template to define the SharedMem manager class. This allows to re-use the same code for sharing data between different hooks using specific struct definitions but the same SharedMem manager.

Instead of storing just a pointer to the heap in shared memory, put the whole shared structure in the memory mapped file for simplicity.

To signal the availability of data from the hook, use a binary semaphore.

This depends on similar changes to ddraw to work properly.