### PR TITLE
Remove empty PostBuildEvent 

### DIFF
--- a/Hook_XWACockpitLook.vcxproj
+++ b/Hook_XWACockpitLook.vcxproj
@@ -120,10 +120,7 @@
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;openvr_api.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent />
-    <PostBuildEvent>
-      <Command>
-      </Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>


### PR DESCRIPTION
… so that it can be inherited from a local Properties file.

With the current value, Properties file does not work and I need to stash and re-apply the change every time I'm pulling from Github.