### PR TITLE
Simhub telemetry

### DIFF
--- a/SharedMem.h
+++ b/SharedMem.h
@@ -55,6 +55,8 @@ struct SharedMemDataTelemetry
 	float pitchInertia;
 	float rollInertia;
 	float accelInertia;
+	bool laserFired;
+	bool warheadFired;
 
 	SharedMemDataTelemetry()
 	{
@@ -67,6 +69,8 @@ struct SharedMemDataTelemetry
 		tgtCargo[0] = 0;
 		tgtSubCmp[0] = 0;
 		shipName[0] = 0;
+		laserFired = false;
+		warheadFired = false;
 
 		yawInertia = 0;
 		pitchInertia = 0;

--- a/SharedMem.h
+++ b/SharedMem.h
@@ -50,7 +50,7 @@ struct SharedMemDataTelemetry
 	char tgtName[TLM_MAX_NAME];
 	char tgtCargo[TLM_MAX_CARGO];
 	char tgtSubCmp[TLM_MAX_SUBCMP];
-	char shipName[TLM_MAX_SHIP_NAME];
+	char shipName[TLM_MAX_SHIP_NAME];	
 	float yawInertia;
 	float pitchInertia;
 	float rollInertia;

--- a/Telemetry.h
+++ b/Telemetry.h
@@ -32,6 +32,8 @@ public:
 	bool underTractorBeam;
 	bool underJammingBeam;
 	ActiveWeapon activeWeapon;
+	bool laserFired;
+	bool warheadFired;
 	float yawInertia;
 	float pitchInertia;
 	float rollInertia;
@@ -53,6 +55,8 @@ public:
 		underTractorBeam = false;
 		underJammingBeam = false;
 		activeWeapon = ActiveWeapon::NONE;
+		laserFired = false;
+		warheadFired = false;
 		yawInertia = 0;
 		pitchInertia = 0;
 		rollInertia = 0;

--- a/XWAFramework.h
+++ b/XWAFramework.h
@@ -52,6 +52,8 @@ const auto DirectInputKeyboardReaquire = (char(*)())0x42B920;
 const auto Vector3Transform = (void* (*)(Vector3_float* vec, XwaMatrix3x3* mat)) 0x439B30;
 const auto DoRotation = (void (*)(int, int, int, __int16)) 0x440E40;
 const auto TransformVector = (int (*)(ObjectEntry*, int, int, int)) 0x4A2FB0;
+const auto LaserEffect = (int(*)()) 0x437280;
+const auto WarheadEffect = (int(*)()) 0x4372F0;
 
 
 // Globals from XWA

--- a/cockpitlook.cpp
+++ b/cockpitlook.cpp
@@ -2411,6 +2411,20 @@ void WriteInertiaData()
 }
 #endif
 
+int LaserEffectHook(int* params)
+{
+	//log_debug("LaserEffectHook() executed");
+	g_pSharedDataTelemetry->laserFired = true;
+	return LaserEffect();
+}
+
+int WarheadEffectHook(int* params)
+{
+	//log_debug("WarheadEffectHook() executed");
+	g_pSharedDataTelemetry->warheadFired = true;
+	return WarheadEffect();
+}
+
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD uReason, LPVOID lpReserved)
 {
 	switch (uReason)

--- a/cockpitlook.cpp
+++ b/cockpitlook.cpp
@@ -1126,6 +1126,7 @@ int UpdateTrackingData()
 	}
 
 	if (g_bUDPEnabled) SendXWADataOverUDP();
+	// TODO: fix shared memory telemetry. Currently it won't work unless UDP is also enabled
 
 	// Restore the position of the external camera if external inertia is enabled.
 	if (bExternalCamera && !g_bInsideMapCameraUpdateHook)
@@ -1790,12 +1791,17 @@ int UpdateTrackingData()
 	bLastExternalCamera = bExternalCamera;
 
 	// Update yaw, pitch, roll, linear inertia for UDP Telemetry:
-	if (g_bUDPEnabled && g_pSharedDataTelemetry)
+	//if (g_bUDPEnabled && g_pSharedDataTelemetry)
+	if (g_bUDPEnabled)
 	{
-		g_pSharedDataTelemetry->yawInertia   = g_fYawInertiaMultiplier   * yawInertia;
+		/*g_pSharedDataTelemetry->yawInertia   = g_fYawInertiaMultiplier   * yawInertia;
 		g_pSharedDataTelemetry->pitchInertia = g_fPitchInertiaMultiplier * pitchInertia;
 		g_pSharedDataTelemetry->rollInertia  = g_fRollInertiaMultiplier  * g_rollInertia;
-		g_pSharedDataTelemetry->accelInertia = g_fAccelInertiaMultiplier * distInertia;
+		g_pSharedDataTelemetry->accelInertia = g_fAccelInertiaMultiplier * distInertia;*/
+		g_PlayerTelemetry.yawInertia = g_fYawInertiaMultiplier * yawInertia;
+		g_PlayerTelemetry.pitchInertia = g_fPitchInertiaMultiplier * pitchInertia;
+		g_PlayerTelemetry.rollInertia = g_fRollInertiaMultiplier * g_rollInertia;
+		g_PlayerTelemetry.accelInertia = g_fAccelInertiaMultiplier * distInertia;
 	}
 
 	if (YawVR::bEnabled)
@@ -2414,14 +2420,14 @@ void WriteInertiaData()
 int LaserEffectHook(int* params)
 {
 	//log_debug("LaserEffectHook() executed");
-	g_pSharedDataTelemetry->laserFired = true;
+	g_PlayerTelemetry.laserFired = true;
 	return LaserEffect();
 }
 
 int WarheadEffectHook(int* params)
 {
 	//log_debug("WarheadEffectHook() executed");
-	g_pSharedDataTelemetry->warheadFired = true;
+	g_PlayerTelemetry.warheadFired = true;	
 	return WarheadEffect();
 }
 

--- a/cockpitlook.h
+++ b/cockpitlook.h
@@ -36,3 +36,6 @@ int CockpitPositionTransformHook(int* params);
 int DoRotationPitchHook(int* params);
 int DoRotationYawHook(int* params);
 int SetupReticleHook(int* params);
+
+int LaserEffectHook(int* params);
+int WarheadEffectHook(int* params);

--- a/hooks.h
+++ b/hooks.h
@@ -35,6 +35,8 @@ static const HookFunction g_hookFunctions[] =
 	{ 0x43FB57, DoRotationPitchHook}, //DoRotation(Pitch)
 	{ 0x43FB67, DoRotationYawHook }, //DoRotation(Yaw)
 	{ 0x4654A6, SetupReticleHook }, //TransformVector() inside SetupReticle()
+	{ 0x491614, LaserEffectHook}, //Capture Laser fire for telemetry
+	{ 0x491B41, WarheadEffectHook},
 };
 
 static const HookPatchItem g_patch[] =
@@ -86,7 +88,20 @@ static const HookPatchItem g_patch[] =
 	{0x057866,"E8D5770000", g_hooksConfig.DisableRandomCamera ? "9090909090" : "E8D5770000"},
 };
 
+static const HookPatchItem g_patchTelemetry[] =
+{
+	//Hooks to capture events for telemetry
+
+	// Hook calls to LaserEffect inside FireLaserCannon()
+	// call (0x5A8B20 - 0x491614) = 0x11750C
+	{0x49160F - 0x400C00, "E86C5CFAFF", "E80C751100"},
+	// Hook call to WarheadEffect inside FireWarhead()
+	// call (0x5A8B20 - 0x491B41) = 0x116FDF
+	{0x491B3C - 0x400C00, "E8AF57FAFF", "E8DF6F1100" },
+};
+
 static const HookPatch g_patches[] =
 {
 	MAKE_HOOK_PATCH("XWA Cockpit Look", g_patch),
+	MAKE_HOOK_PATCH("XWA Telemetry", g_patchTelemetry),
 };


### PR DESCRIPTION
- Added laser and warhead fired events, by hooking the calls to force feedback effect functions.

I refactored the telemetry code using a template and some macros to implement the following:
- Included persistence for ephemeral values that otherwise only last for 1 frame (too short for reliable capturing)
- Add network persistence for sparse telemetry. Changes will be included in UDP packets for a minimum time, configurable by individual parameter in Telemetry.h

Note: SharedMem telemetry currently not working.